### PR TITLE
Ghsync no pointer pk

### DIFF
--- a/generator/types.go
+++ b/generator/types.go
@@ -991,8 +991,7 @@ var identifierTypes = map[string]string{
 	"gopkg.in/src-d/go-kallax.v1.NumericID": "kallax.NumericID",
 	"github.com/satori/go.uuid.UUID":        "kallax.UUID",
 	"github.com/gofrs/uuid.UUID":            "kallax.UUID",
-	"int64":  "kallax.NumericID",
-	"*int64": "kallax.NumericID",
+	"int64": "kallax.NumericID",
 }
 
 func identifierType(f *Field) string {


### PR DESCRIPTION
Revert commit adding pointer primary keys.
The code gets generated, and the inserts on the DB works. But reads end in panic.

ghsync does not use pointer primary keys anymore.

See https://github.com/src-d/ghsync/issues/21 & https://github.com/src-d/ghsync/pull/29.